### PR TITLE
Annotate functions with type hints across multiple Python modules

### DIFF
--- a/dataset_to_h5.py
+++ b/dataset_to_h5.py
@@ -5,6 +5,7 @@ import glob
 import h5py
 import numpy as np
 from tqdm import tqdm
+from typing import List
 from utils.io import save_multi_to_h5
 
 def load_kitti_bin(bin_file: str) -> np.ndarray:
@@ -35,7 +36,7 @@ def split_by_ring(
     return pc[mask]
 
 
-def collect_bin_files(bin_patterns, max_files=None):
+def collect_bin_files(bin_patterns: List[str], max_files: int=None) -> List[str]:
     """
     根據一或多個 glob pattern 收集 .bin 檔案，並依序排序、截斷。
     """
@@ -48,7 +49,7 @@ def collect_bin_files(bin_patterns, max_files=None):
 
 
 def kitti_multiring_to_h5(
-    bin_patterns: list,
+    bin_patterns: List[str],
     output_h5: str,
     orig_rings: int = 64,
     max_files: int = None):

--- a/utils/analyze.py
+++ b/utils/analyze.py
@@ -5,12 +5,14 @@ import matplotlib.pyplot as plt
 import os
 from datetime import datetime
 from tqdm import tqdm
+from typing import List
 
 from utils.io import load_point_clouds   
 from utils.metrics import chamfer_distance_kdtree
 from pointnet_sr_mini import PointNetSRMini   
 
-def analyze_losses(loss_array, title, filename_suffix):
+
+def analyze_losses(loss_array: List[float], title: str, filename_suffix: str):
     loss_array = np.array(loss_array)
     average_loss = np.mean(loss_array)
     std_loss = np.std(loss_array)
@@ -62,7 +64,7 @@ def analyze_losses(loss_array, title, filename_suffix):
     plt.show()
     print(f"\n{title} 曲線圖已儲存到: {save_path}")
 
-def analyze_DL_all(filepath):
+def analyze_DL_all(filepath: str):
     """
     使用兩個 PointNet-SR-mini 模型 (16➔32, 32➔64) 進行推理與 Chamfer Distance 分析。
 
@@ -108,7 +110,7 @@ def analyze_DL_all(filepath):
 
     # --- 定義差集提取 ---
     from scipy.spatial import cKDTree
-    def get_delta(orig: np.ndarray, tgt: np.ndarray, thr=0.05):
+    def get_delta(orig: np.ndarray, tgt: np.ndarray, thr: float=0.05):
         tree_o = cKDTree(orig)
         d2, _ = tree_o.query(tgt, k=1)
         diff_mask = d2 > thr

--- a/utils/interpolation.py
+++ b/utils/interpolation.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.spatial import cKDTree
 
+
 def interpolate_lidar_rings(
     pc: np.ndarray,
     original_num_rings: int = 32,
@@ -63,7 +64,6 @@ def _angle_binning_and_midpoints(
 
     return np.vstack(mids) if mids else np.empty((0, 3))
 
-
 def _enforce_exact_rings(
     merged: np.ndarray,
     target_num_rings: int,
@@ -98,7 +98,6 @@ def _enforce_exact_rings(
         final_pts.append(pts_i)
     return np.vstack(final_pts)
 
-
 def _azimuth_balance(
     merged: np.ndarray,
     target_num_rings: int,
@@ -124,5 +123,3 @@ def _azimuth_balance(
     if additions:
         merged = np.vstack([merged] + additions)
     return merged
-
-

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,7 +1,9 @@
 import h5py
 import numpy as np
+from typing import Tuple, List
 
-def load_point_clouds(h5_path: str):
+
+def load_point_clouds(h5_path: str) -> Tuple[List[np.ndarry], List[np.ndarry], List[np.ndarry]]:
     """
     讀取 HDF5 中的 16/32/64 線點雲
     回傳三個 list[np.ndarray]
@@ -18,7 +20,7 @@ def load_point_clouds(h5_path: str):
             pc64.append(np.array(f['64'][s]))
     return pc16, pc32, pc64
 
-def save_multi_to_h5(output_path, pcs_16, pcs_32, pcs_full):
+def save_multi_to_h5(output_path: str, pcs_16: List[np.ndarray], pcs_32: List[np.ndarray], pcs_full: List[np.ndarray]):
     """
     把三種點雲一起儲存到 h5
     """

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -25,7 +25,7 @@ def chamfer_distance_kdtree(pred: np.ndarray, gt: np.ndarray) -> float:
     loss = np.mean(dist_pred_to_gt**2) + np.mean(dist_gt_to_pred**2)
     return loss
 
-def get_delta(orig: np.ndarray, tgt: np.ndarray, thr=0.05):
+def get_delta(orig: np.ndarray, tgt: np.ndarray, thr=0.05) -> np.ndarray:
     """
     計算 tgt 相對於 orig 的差集 (delta)，
     只保留那些到 orig 最近距離 > thr 的 tgt 點。


### PR DESCRIPTION
此 PR 針對專案內多個 `.py` 檔案的函式補上了靜態型別提示（type hint），以提升：

- 程式可讀性
- IDE 輔助與錯誤檢查能力
- 函式介面的明確度與自我說明性

僅修改了型別標註與註解，**未變動任何邏輯**。